### PR TITLE
Fixes wrong sign of error code

### DIFF
--- a/shouty/enums.py
+++ b/shouty/enums.py
@@ -12,8 +12,8 @@ class ShoutErr(IntEnum):
     CONNECTED = -7
     UNCONNECTED = -8
     UNSUPPORTED = -9
-    BUSY = 10
-    NOTLS = 11
+    BUSY = -10
+    NOTLS = -11
     TLSBADCERT = -12
     RETRY = -13
 


### PR DESCRIPTION
BUSY and NOTLS error codes are also negative: https://github.com/xiph/Icecast-libshout/blob/2dd6cfb7190bdfd4cb5a1fb663f00e630462e9e1/include/shout/shout.h.in#L40-L41